### PR TITLE
Add compact essay tag badges

### DIFF
--- a/src/components/essay-link.tsx
+++ b/src/components/essay-link.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { EssayTagBadge } from "@/components/essay-tag-badge";
 import { cn } from "@/lib/utils/shadcn";
 
 type EssayLinkProps = {
@@ -54,14 +55,16 @@ export function EssayLink({
             </div>
 
             {tags?.length || readingTimeLabel ? (
-                <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-[10px] uppercase tracking-[0.18em] text-foreground/60">
+                <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1.5">
                     {tags?.length ? (
-                        <span className="flex flex-wrap items-center gap-1">
-                            {tags.join(" • ")}
+                        <span className="flex min-w-0 flex-wrap items-center gap-1">
+                            {tags.map((tag) => (
+                                <EssayTagBadge key={tag} tag={tag} />
+                            ))}
                         </span>
                     ) : null}
                     {readingTimeLabel ? (
-                        <span className="ml-auto font-mono tracking-tight text-foreground/40">
+                        <span className="ml-auto font-mono text-[10px] uppercase tracking-tight text-foreground/40">
                             {readingTimeLabel}
                         </span>
                     ) : null}

--- a/src/components/essay-tag-badge.stories.tsx
+++ b/src/components/essay-tag-badge.stories.tsx
@@ -1,0 +1,98 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import type { CSSProperties } from "react";
+
+import { EssayTagBadge } from "@/components/essay-tag-badge";
+
+const sampleTags = ["personal-experience", "business", "software"];
+
+const surfaceSamples = [
+    {
+        name: "Essay light",
+        className: "bg-[#faf7ef]",
+        style: {
+            "--foreground": "#0e1b3d",
+            color: "#0e1b3d",
+        } as CSSProperties,
+    },
+    {
+        name: "Homepage blue",
+        className: "bg-[#0e406f]",
+        style: {
+            "--foreground": "#faf7ef",
+            color: "#faf7ef",
+        } as CSSProperties,
+    },
+    {
+        name: "Deep footer",
+        className: "bg-[#02223f]",
+        style: {
+            "--foreground": "#faf7ef",
+            color: "#faf7ef",
+        } as CSSProperties,
+    },
+    {
+        name: "Project card",
+        className: "bg-[#10263f]",
+        style: {
+            "--foreground": "#faf7ef",
+            color: "#faf7ef",
+        } as CSSProperties,
+    },
+];
+
+function EssayTagBadgeGallery() {
+    return (
+        <main className="min-h-screen bg-background px-6 py-10 text-foreground">
+            <div className="mx-auto flex w-full max-w-4xl flex-col gap-6">
+                <header className="flex flex-col gap-2">
+                    <h1 className="font-serif text-5xl font-bold tracking-tight">
+                        Essay Tag Badge
+                    </h1>
+                    <p className="max-w-2xl text-sm leading-6 text-foreground/60">
+                        Compact tag badges across the essay and homepage
+                        surfaces.
+                    </p>
+                </header>
+
+                <div className="grid gap-4 md:grid-cols-2">
+                    {surfaceSamples.map((surface) => (
+                        <section
+                            key={surface.name}
+                            className={`${surface.className} flex min-h-36 flex-col justify-between rounded-lg border border-foreground/10 p-5 shadow-sm`}
+                            style={surface.style}
+                        >
+                            <h2 className="font-mono text-xs uppercase tracking-[0.18em] text-foreground/55">
+                                {surface.name}
+                            </h2>
+
+                            <div className="flex flex-wrap gap-1">
+                                {sampleTags.map((tag) => (
+                                    <EssayTagBadge key={tag} tag={tag} />
+                                ))}
+                            </div>
+                        </section>
+                    ))}
+                </div>
+            </div>
+        </main>
+    );
+}
+
+const meta = {
+    title: "Components/Essay Tag Badge",
+    component: EssayTagBadge,
+    args: {
+        tag: "personal-experience",
+    },
+    parameters: {
+        layout: "fullscreen",
+    },
+} satisfies Meta<typeof EssayTagBadge>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Backgrounds: Story = {
+    render: () => <EssayTagBadgeGallery />,
+};

--- a/src/components/essay-tag-badge.tsx
+++ b/src/components/essay-tag-badge.tsx
@@ -1,0 +1,22 @@
+import { cn } from "@/lib/utils/shadcn";
+
+interface EssayTagBadgeProps {
+    tag: string;
+    className?: string;
+}
+
+export function EssayTagBadge({ tag, className }: EssayTagBadgeProps) {
+    return (
+        <span
+            className={cn(
+                "inline-flex h-5 max-w-full items-center rounded-[4px] border px-1.5 font-mono text-[9px] font-medium uppercase leading-none tracking-[0.12em] transition-colors",
+                "border-[color:color-mix(in_srgb,var(--foreground)_38%,transparent)] bg-[color:color-mix(in_srgb,var(--foreground)_8%,transparent)] text-[color:color-mix(in_srgb,var(--foreground)_70%,transparent)]",
+                "hover:border-[color:color-mix(in_srgb,var(--foreground)_50%,transparent)] hover:bg-[color:color-mix(in_srgb,var(--foreground)_12%,transparent)] hover:text-[color:color-mix(in_srgb,var(--foreground)_85%,transparent)]",
+                "group-hover:border-[color:color-mix(in_srgb,var(--foreground)_50%,transparent)] group-hover:bg-[color:color-mix(in_srgb,var(--foreground)_12%,transparent)] group-hover:text-[color:color-mix(in_srgb,var(--foreground)_85%,transparent)]",
+                className
+            )}
+        >
+            {tag}
+        </span>
+    );
+}

--- a/src/components/essay/header.tsx
+++ b/src/components/essay/header.tsx
@@ -1,6 +1,7 @@
 import { EssayFrontMatter } from "@/lib/essays/types";
 import { formatDate } from "@/lib/utils/format";
 import { EssayHeroImage } from "../essay-hero-image";
+import { EssayTagBadge } from "../essay-tag-badge";
 import { normalizeUrl } from "@/lib/essays/render/remark/asset-url";
 import { SubstackLink } from "../substack-link";
 
@@ -42,14 +43,9 @@ export function EssayHeader({ frontMatter }: EssayHeaderProps) {
 
                 {/* Row 2: Tags */}
                 {frontMatter.tags.length > 0 && (
-                    <div className="flex flex-wrap gap-2 text-sm uppercase tracking-wider text-foreground/50 font-medium">
+                    <div className="flex flex-wrap gap-1.5">
                         {frontMatter.tags.map((tag) => (
-                            <span
-                                key={tag}
-                                className="hover:text-foreground/80 transition-colors cursor-default"
-                            >
-                                #{tag}
-                            </span>
+                            <EssayTagBadge key={tag} tag={tag} />
                         ))}
                     </div>
                 )}


### PR DESCRIPTION
## Summary
Adds a shared compact essay tag badge and uses it on homepage essay links and essay headers.
Adds a Storybook backgrounds story covering light essay, homepage blue, deep footer, and project card surfaces.

## Testing
Passed: `npm test`, `npm run lint`, `npm run build`, and `npm run build-storybook`.

## Screenshot
See `.context/storybook-tag-badge-backgrounds.png` for the local Storybook visual check.