### PR TITLE
Lighten essay tag badges

### DIFF
--- a/src/components/essay-tag-badge.tsx
+++ b/src/components/essay-tag-badge.tsx
@@ -6,17 +6,19 @@ interface EssayTagBadgeProps {
 }
 
 export function EssayTagBadge({ tag, className }: EssayTagBadgeProps) {
+    const displayTag = tag.startsWith("#") ? tag : `#${tag}`;
+
     return (
         <span
             className={cn(
                 "inline-flex h-5 max-w-full items-center rounded-[4px] border px-1.5 font-mono text-[9px] font-medium uppercase leading-none tracking-[0.12em] transition-colors",
-                "border-[color:color-mix(in_srgb,var(--foreground)_38%,transparent)] bg-[color:color-mix(in_srgb,var(--foreground)_8%,transparent)] text-[color:color-mix(in_srgb,var(--foreground)_70%,transparent)]",
-                "hover:border-[color:color-mix(in_srgb,var(--foreground)_50%,transparent)] hover:bg-[color:color-mix(in_srgb,var(--foreground)_12%,transparent)] hover:text-[color:color-mix(in_srgb,var(--foreground)_85%,transparent)]",
-                "group-hover:border-[color:color-mix(in_srgb,var(--foreground)_50%,transparent)] group-hover:bg-[color:color-mix(in_srgb,var(--foreground)_12%,transparent)] group-hover:text-[color:color-mix(in_srgb,var(--foreground)_85%,transparent)]",
+                "border-[color:color-mix(in_srgb,var(--foreground)_24%,transparent)] bg-[color:color-mix(in_srgb,var(--foreground)_5%,transparent)] text-[color:color-mix(in_srgb,var(--foreground)_56%,transparent)]",
+                "hover:border-[color:color-mix(in_srgb,var(--foreground)_34%,transparent)] hover:bg-[color:color-mix(in_srgb,var(--foreground)_8%,transparent)] hover:text-[color:color-mix(in_srgb,var(--foreground)_70%,transparent)]",
+                "group-hover:border-[color:color-mix(in_srgb,var(--foreground)_34%,transparent)] group-hover:bg-[color:color-mix(in_srgb,var(--foreground)_8%,transparent)] group-hover:text-[color:color-mix(in_srgb,var(--foreground)_70%,transparent)]",
                 className
             )}
         >
-            {tag}
+            {displayTag}
         </span>
     );
 }


### PR DESCRIPTION
## Summary
Lightens the shared essay tag badge styling so tags read less dark across essay and homepage surfaces.
Adds a guarded # prefix in the badge component so tags are clearly presented as tags without duplicating an existing prefix.

## Testing
- npm test -- --runInBand
- git diff --check

## Screenshot
Captured Storybook preview: .context/essay-tag-badge-story/screenshot_127_0_0_1_2026-06-02T14-49-29-577Z_frame1.png