### PR TITLE
Add essay footer actions

### DIFF
--- a/src/components/essay/footer.stories.tsx
+++ b/src/components/essay/footer.stories.tsx
@@ -1,0 +1,53 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import {
+    EssayFooterContent,
+    type EssayFooterPost,
+} from "@/components/essay/footer";
+
+const recentPosts: EssayFooterPost[] = [
+    {
+        href: "/essay/bootstrapping-missing-warning-labels",
+        title: "Bootstrapping's Missing Warning Labels",
+        publishDate: new Date("2025-12-17"),
+    },
+    {
+        href: "/essay/file-over-app-philosophical-case",
+        title: "File Over App: The Philosophical Case",
+        publishDate: new Date("2024-11-26"),
+    },
+    {
+        href: "/essay/overcoming-weak-inclinations",
+        title: "Overcoming Weak Inclinations",
+        publishDate: new Date("2024-12-18"),
+    },
+];
+
+const meta = {
+    title: "Essay/Footer",
+    component: EssayFooterContent,
+    args: {
+        recentPosts,
+    },
+    decorators: [
+        (Story) => (
+            <main className="min-h-screen bg-background px-6 py-10 text-foreground lg:py-16">
+                <article className="mx-auto flex w-full max-w-[720px] flex-col gap-8">
+                    <div className="font-essay text-[1.125rem] leading-[1.7] text-foreground/80">
+                        <p>
+                            This story renders the compact essay outro in the
+                            same max-width column used by essay pages.
+                        </p>
+                    </div>
+                    <Story />
+                </article>
+            </main>
+        ),
+    ],
+} satisfies Meta<typeof EssayFooterContent>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const CompactColumns: Story = {};

--- a/src/components/essay/footer.tsx
+++ b/src/components/essay/footer.tsx
@@ -1,10 +1,11 @@
 import type { ReactNode } from "react";
 import Image from "next/image";
 import Link from "next/link";
-import { ArrowUpRight } from "lucide-react";
+import { ArrowUpRight, Rss } from "lucide-react";
 
-import { Icon, SubstackIcon } from "@/components/icon";
+import { Icon, SubstackIcon, TwitterIcon } from "@/components/icon";
 import { getAllEssays } from "@/lib/essays";
+import { RSS_FEED_PATH } from "@/lib/site";
 import { cn } from "@/lib/utils/shadcn";
 import {
     getRecentEssayFooterPosts,
@@ -21,6 +22,13 @@ interface FooterAction {
     iconShellClassName?: string;
 }
 
+interface FollowAction {
+    href: string;
+    label: string;
+    icon: ReactNode;
+    actionClassName: string;
+}
+
 interface EssayFooterProps {
     currentSlug: string;
 }
@@ -29,12 +37,29 @@ interface EssayFooterContentProps {
     recentPosts: EssayFooterPost[];
 }
 
-const subscribeAction: FooterAction = {
-    href: "https://alessandrofv.substack.com/?ref=alessandrofv.com",
-    label: "Subscribe",
-    description: "Subscribe by email",
-    icon: <Icon icon={SubstackIcon} className="size-4" />,
-};
+const followActions: FollowAction[] = [
+    {
+        href: "https://alessandrofv.substack.com/?ref=alessandrofv.com",
+        label: "Substack",
+        icon: <Icon icon={SubstackIcon} className="size-4" />,
+        actionClassName:
+            "bg-[#FF6719] text-white shadow-[#FF6719]/20 hover:bg-[#FF6719]/90 hover:shadow-[#FF6719]/25 focus-visible:ring-[#FF6719]/35",
+    },
+    {
+        href: "https://x.com/AFV_7?ref=alessandrofv.com",
+        label: "Twitter",
+        icon: <Icon icon={TwitterIcon} className="size-4" />,
+        actionClassName:
+            "bg-[#1D9BF0] text-white shadow-[#1D9BF0]/20 hover:bg-[#1D9BF0]/90 hover:shadow-[#1D9BF0]/25 focus-visible:ring-[#1D9BF0]/35",
+    },
+    {
+        href: RSS_FEED_PATH,
+        label: "RSS",
+        icon: <Rss className="size-4" aria-hidden />,
+        actionClassName:
+            "bg-primary text-primary-foreground shadow-primary/15 hover:bg-primary/90 hover:shadow-primary/20 focus-visible:ring-primary/25",
+    },
+];
 
 const projectActions: FooterAction[] = [
     {
@@ -117,7 +142,7 @@ function FooterActionLink({ action }: { action: FooterAction }) {
         >
             <span
                 className={cn(
-                    "flex size-8 shrink-0 items-center justify-center overflow-hidden rounded-md border border-foreground/10 bg-background text-primary",
+                    "flex size-8 shrink-0 items-center justify-center overflow-hidden border border-foreground/10 bg-background text-primary",
                     action.iconShellClassName
                 )}
             >
@@ -141,21 +166,25 @@ function FooterActionLink({ action }: { action: FooterAction }) {
     );
 }
 
-function SubscribeActionLink({ action }: { action: FooterAction }) {
+function FollowActionLink({ action }: { action: FollowAction }) {
+    const external = isExternalHref(action.href);
+
     return (
         <Link
             href={action.href}
-            target="_blank"
-            rel="noreferrer noopener"
+            {...(external
+                ? { target: "_blank", rel: "noreferrer noopener" }
+                : {})}
             className={cn(
-                "group flex min-h-12 w-full min-w-0 items-center justify-center gap-3 rounded-md px-4 py-3",
-                "bg-[#FF6719] text-sm font-bold uppercase leading-none tracking-[0.16em] text-white shadow-md shadow-[#FF6719]/20",
-                "transition-all hover:-translate-y-0.5 hover:bg-[#FF6719]/90 hover:shadow-lg hover:shadow-[#FF6719]/25",
-                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#FF6719]/35 active:translate-y-0"
+                "group flex min-h-10 w-full min-w-0 items-center justify-center gap-2.5 rounded-md px-3 py-2",
+                "text-[12px] font-bold uppercase leading-none tracking-[0.16em] shadow-md",
+                "transition-all hover:-translate-y-0.5 hover:shadow-lg",
+                "focus-visible:outline-none focus-visible:ring-2 active:translate-y-0",
+                action.actionClassName
             )}
             prefetch={false}
         >
-            {action.icon}
+            <span className="shrink-0">{action.icon}</span>
             <span className="truncate">{action.label}</span>
         </Link>
     );
@@ -195,8 +224,13 @@ export function EssayFooterContent({ recentPosts }: EssayFooterContentProps) {
                     </FooterColumn>
 
                     <FooterColumn title="Follow">
-                        <div>
-                            <SubscribeActionLink action={subscribeAction} />
+                        <div className="space-y-2">
+                            {followActions.map((action) => (
+                                <FollowActionLink
+                                    key={action.href}
+                                    action={action}
+                                />
+                            ))}
                         </div>
                     </FooterColumn>
 

--- a/src/components/essay/footer.tsx
+++ b/src/components/essay/footer.tsx
@@ -1,11 +1,10 @@
 import type { ReactNode } from "react";
 import Image from "next/image";
 import Link from "next/link";
-import { ArrowUpRight, Rss } from "lucide-react";
+import { ArrowUpRight } from "lucide-react";
 
-import { Icon, SubstackIcon, TwitterIcon } from "@/components/icon";
+import { Icon, SubstackIcon } from "@/components/icon";
 import { getAllEssays } from "@/lib/essays";
-import { RSS_FEED_PATH } from "@/lib/site";
 import { cn } from "@/lib/utils/shadcn";
 import {
     getRecentEssayFooterPosts,
@@ -30,32 +29,18 @@ interface EssayFooterContentProps {
     recentPosts: EssayFooterPost[];
 }
 
-const followActions: FooterAction[] = [
-    {
-        href: RSS_FEED_PATH,
-        label: "RSS",
-        description: "New essays in your reader",
-        icon: <Rss className="size-4" aria-hidden />,
-    },
-    {
-        href: "https://alessandrofv.substack.com/?ref=alessandrofv.com",
-        label: "Substack",
-        description: "Subscribe by email",
-        icon: <Icon icon={SubstackIcon} className="size-4" />,
-    },
-    {
-        href: "https://x.com/AFV_7?ref=alessandrofv.com",
-        label: "Twitter",
-        description: "Short updates and notes",
-        icon: <Icon icon={TwitterIcon} className="size-4" />,
-    },
-];
+const subscribeAction: FooterAction = {
+    href: "https://alessandrofv.substack.com/?ref=alessandrofv.com",
+    label: "Subscribe",
+    description: "Subscribe by email",
+    icon: <Icon icon={SubstackIcon} className="size-4" />,
+};
 
 const projectActions: FooterAction[] = [
     {
         href: "https://janus.cards",
-        label: "AI Flashcard for Anki and Mochi",
-        description: "AI flashcards for durable memory",
+        label: "Janus",
+        description: "AI Flashcards",
         icon: (
             <Image
                 src="/janus-no-background.svg"
@@ -70,7 +55,7 @@ const projectActions: FooterAction[] = [
     {
         href: "https://github.com/franklin-md/franklin-mono",
         label: "Franklin",
-        description: "Personal AI agents for Obsidian",
+        description: "Agents in Obsidian",
         icon: (
             <Image
                 src="/franklin-kite.png"
@@ -156,6 +141,26 @@ function FooterActionLink({ action }: { action: FooterAction }) {
     );
 }
 
+function SubscribeActionLink({ action }: { action: FooterAction }) {
+    return (
+        <Link
+            href={action.href}
+            target="_blank"
+            rel="noreferrer noopener"
+            className={cn(
+                "group flex min-h-12 w-full min-w-0 items-center justify-center gap-3 rounded-md px-4 py-3",
+                "bg-[#FF6719] text-sm font-bold uppercase leading-none tracking-[0.16em] text-white shadow-md shadow-[#FF6719]/20",
+                "transition-all hover:-translate-y-0.5 hover:bg-[#FF6719]/90 hover:shadow-lg hover:shadow-[#FF6719]/25",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#FF6719]/35 active:translate-y-0"
+            )}
+            prefetch={false}
+        >
+            {action.icon}
+            <span className="truncate">{action.label}</span>
+        </Link>
+    );
+}
+
 function RecentPostLink({ post }: { post: EssayFooterPost }) {
     return (
         <Link
@@ -190,13 +195,8 @@ export function EssayFooterContent({ recentPosts }: EssayFooterContentProps) {
                     </FooterColumn>
 
                     <FooterColumn title="Follow">
-                        <div className="space-y-1">
-                            {followActions.map((action) => (
-                                <FooterActionLink
-                                    key={action.href}
-                                    action={action}
-                                />
-                            ))}
+                        <div>
+                            <SubscribeActionLink action={subscribeAction} />
                         </div>
                     </FooterColumn>
 

--- a/src/components/essay/footer.tsx
+++ b/src/components/essay/footer.tsx
@@ -142,7 +142,7 @@ function FooterActionLink({ action }: { action: FooterAction }) {
         >
             <span
                 className={cn(
-                    "flex size-8 shrink-0 items-center justify-center overflow-hidden border border-foreground/10 bg-background text-primary",
+                    "flex size-8 shrink-0 items-center justify-center overflow-hidden rounded-md border border-foreground/10 bg-background text-primary",
                     action.iconShellClassName
                 )}
             >

--- a/src/components/essay/footer.tsx
+++ b/src/components/essay/footer.tsx
@@ -1,37 +1,224 @@
+import type { ReactNode } from "react";
+import Image from "next/image";
 import Link from "next/link";
-import { cn } from "@/lib/utils/shadcn";
-import { SubstackLink } from "../substack-link";
+import { ArrowUpRight, Rss } from "lucide-react";
 
-export function EssayFooter() {
-    return (
-        <div className="flex flex-col gap-4 mt-8">
-            <SubstackLink
-                url="https://alessandrofv.substack.com/"
-                variant="subscribe"
+import { Icon, SubstackIcon, TwitterIcon } from "@/components/icon";
+import { getAllEssays } from "@/lib/essays";
+import { RSS_FEED_PATH } from "@/lib/site";
+import { cn } from "@/lib/utils/shadcn";
+import {
+    getRecentEssayFooterPosts,
+    type EssayFooterPost,
+} from "./recent-posts";
+
+export type { EssayFooterPost } from "./recent-posts";
+
+interface FooterAction {
+    href: string;
+    label: string;
+    description: string;
+    icon: ReactNode;
+    iconShellClassName?: string;
+}
+
+interface EssayFooterProps {
+    currentSlug: string;
+}
+
+interface EssayFooterContentProps {
+    recentPosts: EssayFooterPost[];
+}
+
+const followActions: FooterAction[] = [
+    {
+        href: RSS_FEED_PATH,
+        label: "RSS",
+        description: "New essays in your reader",
+        icon: <Rss className="size-4" aria-hidden />,
+    },
+    {
+        href: "https://alessandrofv.substack.com/?ref=alessandrofv.com",
+        label: "Substack",
+        description: "Subscribe by email",
+        icon: <Icon icon={SubstackIcon} className="size-4" />,
+    },
+    {
+        href: "https://x.com/AFV_7?ref=alessandrofv.com",
+        label: "Twitter",
+        description: "Short updates and notes",
+        icon: <Icon icon={TwitterIcon} className="size-4" />,
+    },
+];
+
+const projectActions: FooterAction[] = [
+    {
+        href: "https://janus.cards",
+        label: "AI Flashcard for Anki and Mochi",
+        description: "AI flashcards for durable memory",
+        icon: (
+            <Image
+                src="/janus-no-background.svg"
+                alt=""
+                width={32}
+                height={32}
+                className="size-full object-contain"
             />
-            <div
+        ),
+        iconShellClassName: "border-primary/15 bg-[#23395B]",
+    },
+    {
+        href: "https://github.com/franklin-md/franklin-mono",
+        label: "Franklin",
+        description: "Personal AI agents for Obsidian",
+        icon: (
+            <Image
+                src="/franklin-kite.png"
+                alt=""
+                width={32}
+                height={32}
+                className="size-full object-cover"
+            />
+        ),
+        iconShellClassName: "overflow-hidden border-primary/10 bg-background",
+    },
+];
+
+function formatPostDate(date: Date): string {
+    return new Intl.DateTimeFormat("en-US", {
+        month: "short",
+        day: "2-digit",
+    })
+        .format(date)
+        .toUpperCase();
+}
+
+function isExternalHref(href: string): boolean {
+    return /^https?:\/\//.test(href);
+}
+
+function FooterColumn({
+    title,
+    children,
+}: {
+    title: string;
+    children: ReactNode;
+}) {
+    return (
+        <section className="min-w-0">
+            <h2 className="mb-3 text-[11px] font-bold uppercase tracking-[0.18em] text-foreground/45">
+                {title}
+            </h2>
+            {children}
+        </section>
+    );
+}
+
+function FooterActionLink({ action }: { action: FooterAction }) {
+    const external = isExternalHref(action.href);
+
+    return (
+        <Link
+            href={action.href}
+            className={cn(
+                "group flex min-w-0 items-center gap-3 rounded-md px-2.5 py-2",
+                "text-foreground/80 transition-colors hover:bg-primary/5 hover:text-foreground",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/25"
+            )}
+            {...(external
+                ? { target: "_blank", rel: "noreferrer noopener" }
+                : {})}
+            prefetch={false}
+        >
+            <span
                 className={cn(
-                    "pt-4",
-                    "text-lg text-foreground/60 leading-relaxed font-serif italic"
+                    "flex size-8 shrink-0 items-center justify-center overflow-hidden rounded-md border border-foreground/10 bg-background text-primary",
+                    action.iconShellClassName
                 )}
             >
-                <p className="max-w-2xl">
-                    I write these essays to explore tools for better thinking,
-                    learning, and remembering, as well as the business mindset
-                    required to bring these tools into existence. If you found
-                    this valuable, you might enjoy{" "}
-                    <Link
-                        href="https://janus.cards"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="font-medium text-primary underline underline-offset-8 decoration-primary/30 transition-all hover:decoration-primary"
-                    >
-                        Janus
-                    </Link>
-                    , my tool for turning what you read and learn into lasting
-                    memory.
-                </p>
-            </div>
-        </div>
+                {action.icon}
+            </span>
+            <span className="min-w-0">
+                <span className="flex items-center gap-1 text-[13px] font-semibold leading-none">
+                    {action.label}
+                    {external ? (
+                        <ArrowUpRight
+                            className="size-3 text-foreground/35 transition-transform group-hover:-translate-y-0.5 group-hover:translate-x-0.5"
+                            aria-hidden
+                        />
+                    ) : null}
+                </span>
+                <span className="mt-1 block truncate text-[11px] leading-tight text-foreground/45">
+                    {action.description}
+                </span>
+            </span>
+        </Link>
     );
+}
+
+function RecentPostLink({ post }: { post: EssayFooterPost }) {
+    return (
+        <Link
+            href={post.href}
+            className={cn(
+                "group block rounded-md px-2.5 py-2 transition-colors hover:bg-primary/5",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/25"
+            )}
+            prefetch={false}
+        >
+            <span className="block truncate text-[13px] font-semibold leading-tight text-foreground/80 group-hover:text-foreground">
+                {post.title}
+            </span>
+            <span className="mt-1 block font-mono text-[9px] uppercase tracking-[0.16em] text-foreground/40">
+                {formatPostDate(post.publishDate)}
+            </span>
+        </Link>
+    );
+}
+
+export function EssayFooterContent({ recentPosts }: EssayFooterContentProps) {
+    return (
+        <footer className="mt-8 border-t border-foreground/10 pt-6 md:-mx-4 lg:-mx-16">
+            <div className="rounded-lg border border-foreground/10 bg-card/85 p-4 shadow-[0_22px_55px_rgba(14,27,61,0.14)]">
+                <div className="grid gap-5 md:grid-cols-[minmax(0,1.65fr)_minmax(0,0.9fr)_minmax(0,0.9fr)]">
+                    <FooterColumn title="Recent Posts">
+                        <div className="space-y-1">
+                            {recentPosts.map((post) => (
+                                <RecentPostLink key={post.href} post={post} />
+                            ))}
+                        </div>
+                    </FooterColumn>
+
+                    <FooterColumn title="Follow">
+                        <div className="space-y-1">
+                            {followActions.map((action) => (
+                                <FooterActionLink
+                                    key={action.href}
+                                    action={action}
+                                />
+                            ))}
+                        </div>
+                    </FooterColumn>
+
+                    <FooterColumn title="Projects">
+                        <div className="space-y-1">
+                            {projectActions.map((action) => (
+                                <FooterActionLink
+                                    key={action.href}
+                                    action={action}
+                                />
+                            ))}
+                        </div>
+                    </FooterColumn>
+                </div>
+            </div>
+        </footer>
+    );
+}
+
+export async function EssayFooter({ currentSlug }: EssayFooterProps) {
+    const essays = await getAllEssays();
+    const recentPosts = getRecentEssayFooterPosts(essays, currentSlug);
+
+    return <EssayFooterContent recentPosts={recentPosts} />;
 }

--- a/src/components/essay/index.tsx
+++ b/src/components/essay/index.tsx
@@ -14,7 +14,7 @@ export function Essay({ essay }: EssayProps) {
         <article className="mx-auto flex w-full max-w-[720px] flex-col gap-4 px-6 py-8 lg:gap-8 lg:py-12">
             <EssayHeader frontMatter={frontMatter} />
             <EssayBody essay={essay} />
-            <EssayFooter />
+            <EssayFooter currentSlug={essay.slug} />
         </article>
     );
 }

--- a/src/components/essay/recent-posts.ts
+++ b/src/components/essay/recent-posts.ts
@@ -1,0 +1,38 @@
+const DEFAULT_RECENT_POST_LIMIT = 3;
+
+export interface EssayFooterPostSource {
+    slug: string;
+    frontMatter: {
+        title: string;
+        publishDate: Date;
+        draft?: boolean;
+    };
+}
+
+export interface EssayFooterPost {
+    href: string;
+    title: string;
+    publishDate: Date;
+}
+
+export function getRecentEssayFooterPosts(
+    essays: EssayFooterPostSource[],
+    currentSlug: string,
+    limit = DEFAULT_RECENT_POST_LIMIT
+): EssayFooterPost[] {
+    return essays
+        .filter(
+            (essay) => essay.slug !== currentSlug && !essay.frontMatter.draft
+        )
+        .sort(
+            (a, b) =>
+                b.frontMatter.publishDate.getTime() -
+                a.frontMatter.publishDate.getTime()
+        )
+        .slice(0, limit)
+        .map((essay) => ({
+            href: `/essay/${essay.slug}`,
+            title: essay.frontMatter.title,
+            publishDate: essay.frontMatter.publishDate,
+        }));
+}

--- a/src/components/essay/tests/recent-posts.test.ts
+++ b/src/components/essay/tests/recent-posts.test.ts
@@ -1,0 +1,76 @@
+import {
+    getRecentEssayFooterPosts,
+    type EssayFooterPostSource,
+} from "@/components/essay/recent-posts";
+
+function createPost(
+    slug: string,
+    title: string,
+    publishDate: string,
+    draft = false
+): EssayFooterPostSource {
+    return {
+        slug,
+        frontMatter: {
+            title,
+            publishDate: new Date(publishDate),
+            draft,
+        },
+    };
+}
+
+describe("getRecentEssayFooterPosts", () => {
+    it("excludes the current essay from the recent posts column", () => {
+        const posts = getRecentEssayFooterPosts(
+            [
+                createPost("current", "Current Essay", "2026-01-03"),
+                createPost("next", "Next Essay", "2026-01-02"),
+            ],
+            "current"
+        );
+
+        expect(posts).toEqual([
+            {
+                href: "/essay/next",
+                title: "Next Essay",
+                publishDate: new Date("2026-01-02"),
+            },
+        ]);
+    });
+
+    it("limits the footer to the three newest non-draft posts", () => {
+        const posts = getRecentEssayFooterPosts(
+            [
+                createPost("draft", "Draft Essay", "2026-01-05", true),
+                createPost("first", "First Essay", "2026-01-04"),
+                createPost("second", "Second Essay", "2026-01-03"),
+                createPost("third", "Third Essay", "2026-01-02"),
+                createPost("fourth", "Fourth Essay", "2026-01-01"),
+            ],
+            "not-present"
+        );
+
+        expect(posts.map((post) => post.title)).toEqual([
+            "First Essay",
+            "Second Essay",
+            "Third Essay",
+        ]);
+    });
+
+    it("sorts newest first before applying the recent post limit", () => {
+        const posts = getRecentEssayFooterPosts(
+            [
+                createPost("old", "Old Essay", "2026-01-01"),
+                createPost("new", "New Essay", "2026-01-03"),
+                createPost("middle", "Middle Essay", "2026-01-02"),
+            ],
+            "not-present",
+            2
+        );
+
+        expect(posts.map((post) => post.href)).toEqual([
+            "/essay/new",
+            "/essay/middle",
+        ]);
+    });
+});


### PR DESCRIPTION
## Summary
- Replaces the essay outro with a compact footer containing recent posts, follow links, and project links.
- Adds recent-post filtering/sorting logic so the current essay and drafts are excluded.
- Adds Storybook coverage for the footer state.

## Testing
- `git diff --check`
- `npm test -- --runInBand`
- `npm run lint`
- `npm run build`
- `npm run build-storybook`

Note: Storybook build completed successfully with existing Webpack asset-size warnings.