### PR TITLE
Fix iOS Substack essay header CTA

### DIFF
--- a/src/components/essay/header.stories.tsx
+++ b/src/components/essay/header.stories.tsx
@@ -1,0 +1,80 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { EssayHeader } from "@/components/essay/header";
+import type { EssayFrontMatter } from "@/lib/essays/types";
+
+const substackFrontMatter: EssayFrontMatter = {
+    title: "Bootstrapping's Missing Warning Labels",
+    subtitle:
+        "What startup advice misses when the company is one person and the runway is personal.",
+    description: "Storybook preview for a Substack-backed essay header.",
+    slug: "bootstrapping-missing-warning-labels",
+    publishDate: new Date("2025-12-17"),
+    readingTime: 7,
+    tags: ["personal-experience", "business"],
+    authors: ["Alessandro Farace"],
+    draft: false,
+    canonicalUrl:
+        "https://alessandrofv.substack.com/p/bootstrappings-missing-warning-labels",
+};
+
+const siteOnlyFrontMatter: EssayFrontMatter = {
+    ...substackFrontMatter,
+    title: "The Path Less Travelled",
+    subtitle: "A quieter essay header without an external canonical CTA.",
+    description: "Storybook preview for a site-native essay header.",
+    slug: "path-less-travelled",
+    publishDate: new Date("2024-09-03"),
+    readingTime: 5,
+    tags: ["personal"],
+    canonicalUrl: undefined,
+};
+
+interface EssayHeaderStoryProps {
+    frontMatter: EssayFrontMatter;
+    width?: number;
+}
+
+function EssayHeaderStory({ frontMatter, width = 720 }: EssayHeaderStoryProps) {
+    return (
+        <main className="min-h-screen bg-background px-6 py-10 text-foreground">
+            <article
+                className="mx-auto flex w-full flex-col gap-4"
+                style={{ maxWidth: width }}
+            >
+                <EssayHeader frontMatter={frontMatter} />
+            </article>
+        </main>
+    );
+}
+
+const meta = {
+    title: "Essay/Header",
+    component: EssayHeaderStory,
+    args: {
+        frontMatter: substackFrontMatter,
+        width: 720,
+    },
+    parameters: {
+        layout: "fullscreen",
+    },
+} satisfies Meta<typeof EssayHeaderStory>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const SubstackCanonical: Story = {};
+
+export const MobileSubstackCanonical: Story = {
+    args: {
+        frontMatter: substackFrontMatter,
+        width: 342,
+    },
+};
+
+export const SiteOnly: Story = {
+    args: {
+        frontMatter: siteOnlyFrontMatter,
+    },
+};

--- a/src/components/essay/header.tsx
+++ b/src/components/essay/header.tsx
@@ -28,20 +28,18 @@ export function EssayHeader({ frontMatter }: EssayHeaderProps) {
             </div>
 
             <div className="flex flex-col gap-2">
-                {/* Row 1: Date, Reading Time, and optional Substack Button */}
-                <div className="flex items-center gap-x-4 text-sm uppercase tracking-wider text-foreground/50 font-medium w-full">
+                <div className="flex items-center gap-x-4 text-sm uppercase tracking-wider text-foreground/50 font-medium">
                     <span>{formattedDate}</span>
                     <span className="w-1 h-1 rounded-full bg-foreground/20" />
                     <span>{readingTimeLabel}</span>
-                    {isSubstack && (
-                        <SubstackLink
-                            url={frontMatter.canonicalUrl!}
-                            className="ml-auto"
-                        />
-                    )}
                 </div>
 
-                {/* Row 2: Tags */}
+                {isSubstack && (
+                    <div className="flex">
+                        <SubstackLink url={frontMatter.canonicalUrl!} />
+                    </div>
+                )}
+
                 {frontMatter.tags.length > 0 && (
                     <div className="flex flex-wrap gap-1.5">
                         {frontMatter.tags.map((tag) => (

--- a/src/components/essay/header.tsx
+++ b/src/components/essay/header.tsx
@@ -28,17 +28,20 @@ export function EssayHeader({ frontMatter }: EssayHeaderProps) {
             </div>
 
             <div className="flex flex-col gap-2">
-                <div className="flex items-center gap-x-4 text-sm uppercase tracking-wider text-foreground/50 font-medium">
-                    <span>{formattedDate}</span>
-                    <span className="w-1 h-1 rounded-full bg-foreground/20" />
-                    <span>{readingTimeLabel}</span>
-                </div>
-
-                {isSubstack && (
-                    <div className="flex">
-                        <SubstackLink url={frontMatter.canonicalUrl!} />
+                <div className="flex flex-col items-start gap-2 lg:flex-row lg:items-center">
+                    <div className="flex items-center gap-x-4 text-sm uppercase tracking-wider text-foreground/50 font-medium">
+                        <span>{formattedDate}</span>
+                        <span className="w-1 h-1 rounded-full bg-foreground/20" />
+                        <span>{readingTimeLabel}</span>
                     </div>
-                )}
+
+                    {isSubstack && (
+                        <SubstackLink
+                            url={frontMatter.canonicalUrl!}
+                            className="lg:ml-auto"
+                        />
+                    )}
+                </div>
 
                 {frontMatter.tags.length > 0 && (
                     <div className="flex flex-wrap gap-1.5">

--- a/src/components/substack-link.tsx
+++ b/src/components/substack-link.tsx
@@ -30,7 +30,7 @@ export function SubstackLink({ url, variant = "read", className }: SubstackLinkP
             target="_blank"
             rel="noopener noreferrer"
             className={cn(
-                "flex items-center gap-2 whitespace-nowrap rounded-full border border-[#FF6719]/20 bg-[#FF6719]/10 px-2.5 py-1 text-xs font-bold uppercase tracking-tight text-[#FF6719] transition-colors hover:bg-[#FF6719]/20",
+                "flex items-center gap-2 whitespace-nowrap rounded-[4px] border border-[#FF6719]/20 bg-[#FF6719]/10 px-2.5 py-1 text-xs font-bold uppercase tracking-tight text-[#FF6719] transition-colors hover:bg-[#FF6719]/20",
                 className
             )}
         >

--- a/src/components/substack-link.tsx
+++ b/src/components/substack-link.tsx
@@ -30,7 +30,7 @@ export function SubstackLink({ url, variant = "read", className }: SubstackLinkP
             target="_blank"
             rel="noopener noreferrer"
             className={cn(
-                "flex items-center gap-2 rounded-full border border-[#FF6719]/20 bg-[#FF6719]/10 px-2.5 py-1 text-xs font-bold uppercase tracking-tight text-[#FF6719] hover:bg-[#FF6719]/20 transition-colors",
+                "flex items-center gap-2 whitespace-nowrap rounded-full border border-[#FF6719]/20 bg-[#FF6719]/10 px-2.5 py-1 text-xs font-bold uppercase tracking-tight text-[#FF6719] transition-colors hover:bg-[#FF6719]/20",
                 className
             )}
         >


### PR DESCRIPTION
## Summary
Fixes the iOS essay header layout by moving the Substack CTA out of the date/read-time row and keeping the CTA label on one line.
Adds Storybook coverage for desktop Substack, mobile Substack, and site-only essay header states.

## Testing
- npm test
- npm run lint
- npm run build
- npm run build-storybook -- --quiet
- git diff --check
- Visual check at 390px wide with screenshots saved under .context/current-ios-header and .context/fixed-ios-header