### PR TITLE
Fix Obsidian essay asset embeds

### DIFF
--- a/src/lib/essays/render/index.tsx
+++ b/src/lib/essays/render/index.tsx
@@ -10,7 +10,7 @@ import rehypePrism from "rehype-prism-plus";
 
 import { remarkEssayAssetPaths } from "./remark/asset-paths";
 import { rehypeAbsoluteUrls } from "./rehype/absolute-urls";
-import { remarkObsidianCallouts } from "./remark/obsidian";
+import { remarkObsidianMarkdown } from "./remark/obsidian";
 import type { EssayDocument } from "../types";
 
 import { Fragment, jsx, jsxs } from "react/jsx-runtime";
@@ -28,7 +28,7 @@ function createEssayProcessor() {
     return unified()
         .use(remarkParse)
         .use(remarkGfm)
-        .use(remarkObsidianCallouts)
+        .use(remarkObsidianMarkdown)
         .use(remarkEssayAssetPaths)
         .use(remarkRehype)
         .use(rehypeRaw)

--- a/src/lib/essays/render/remark/obsidian/embed.ts
+++ b/src/lib/essays/render/remark/obsidian/embed.ts
@@ -1,0 +1,151 @@
+import type { Image, PhrasingContent, Root, Text } from "mdast";
+import { visit } from "unist-util-visit";
+
+const IMAGE_EMBED_REGEX = /!\[\[([^\]\n]+)\]\]/g;
+const SIZE_HINT_REGEX = /^(\d+)(?:x(\d+))?$/;
+
+type ParentWithPhrasingChildren = {
+    children: PhrasingContent[];
+};
+
+interface ParsedImageEmbed {
+    alt: string;
+    height?: number;
+    url: string;
+    width?: number;
+}
+
+function parseSizeHint(value: string): Pick<
+    ParsedImageEmbed,
+    "height" | "width"
+> | null {
+    const match = value.match(SIZE_HINT_REGEX);
+
+    if (!match) {
+        return null;
+    }
+
+    return {
+        width: Number(match[1]),
+        ...(match[2] ? { height: Number(match[2]) } : {}),
+    };
+}
+
+function parseImageEmbed(value: string): ParsedImageEmbed | null {
+    const [rawUrl, ...rawOptions] = value
+        .split("|")
+        .map((part) => part.trim());
+    const url = rawUrl;
+
+    if (!url) {
+        return null;
+    }
+
+    const options = rawOptions.filter(Boolean);
+    const size = options
+        .map((option) => parseSizeHint(option))
+        .find((option) => option !== null);
+    const explicitAlt = options.find((option) => parseSizeHint(option) === null);
+
+    return {
+        alt: explicitAlt ?? url,
+        url,
+        ...size,
+    };
+}
+
+function createImageNode(embed: ParsedImageEmbed): Image {
+    const hProperties =
+        embed.width || embed.height
+            ? {
+                  ...(embed.width ? { width: embed.width } : {}),
+                  ...(embed.height ? { height: embed.height } : {}),
+              }
+            : undefined;
+
+    return {
+        type: "image",
+        url: embed.url,
+        alt: embed.alt,
+        ...(hProperties
+            ? {
+                  data: {
+                      hProperties,
+                  },
+              }
+            : {}),
+    };
+}
+
+function replaceImageEmbeds(value: string): PhrasingContent[] | null {
+    const children: PhrasingContent[] = [];
+    let lastIndex = 0;
+    let foundEmbed = false;
+
+    IMAGE_EMBED_REGEX.lastIndex = 0;
+
+    for (const match of value.matchAll(IMAGE_EMBED_REGEX)) {
+        const index = match.index ?? 0;
+        const embed = parseImageEmbed(match[1]);
+
+        if (index > lastIndex) {
+            children.push({
+                type: "text",
+                value: value.slice(lastIndex, index),
+            });
+        }
+
+        children.push(
+            embed
+                ? createImageNode(embed)
+                : {
+                      type: "text",
+                      value: match[0],
+                  }
+        );
+        foundEmbed = true;
+        lastIndex = index + match[0].length;
+    }
+
+    if (!foundEmbed) {
+        return null;
+    }
+
+    if (lastIndex < value.length) {
+        children.push({
+            type: "text",
+            value: value.slice(lastIndex),
+        });
+    }
+
+    return children;
+}
+
+/**
+ * Output shape:
+ * - `![[diagram.png]]` becomes the same mdast image shape as
+ *   `![diagram.png](diagram.png)` so the asset-path pass can normalize it.
+ * - `![[diagram.png|Specific alt text]]` uses the alias as alt text.
+ * - `![[diagram.png|400]]` preserves the size hint as image metadata.
+ */
+export function transformObsidianImageEmbeds(tree: Root): void {
+    visit(tree, "text", (node: Text, index, parent) => {
+        if (typeof index !== "number" || !parent || !("children" in parent)) {
+            return;
+        }
+
+        const replacement = replaceImageEmbeds(node.value);
+
+        if (!replacement) {
+            return;
+        }
+
+        (parent as ParentWithPhrasingChildren).children.splice(
+            index,
+            1,
+            ...replacement
+        );
+
+        return index + replacement.length;
+    });
+}

--- a/src/lib/essays/render/remark/obsidian/index.ts
+++ b/src/lib/essays/render/remark/obsidian/index.ts
@@ -2,19 +2,14 @@ import type { Root } from "mdast";
 import type { Plugin } from "unified";
 
 import { transformObsidianCallouts } from "./callout";
+import { transformObsidianImageEmbeds } from "./embed";
 
 /**
- * Converts only Obsidian callout blockquotes into ordinary mdast blockquotes.
- * Output shape is documented in `callout.ts`.
+ * Converts supported Obsidian markdown into ordinary mdast nodes:
+ * - callout blockquotes documented in `callout.ts`
+ * - image embeds documented in `embed.ts`
  *
  * Remaining Obsidian markdown support to add:
- * - Image embeds: `![[buttons-without-prefix.png]]` should become the same
- *   mdast image shape as `![buttons-without-prefix.png](buttons-without-prefix.png)`
- *   so `remarkEssayAssetPaths` can normalize it to `/essay-assets/...`. Aliases
- *   such as `![[diagram.png|Specific alt text]]` should use the alias as the
- *   image alt text, while the asset filename remains the URL source. Size hints
- *   such as `![[diagram.png|400]]` are worth preserving as metadata only if the
- *   essay renderer later supports explicit image dimensions.
  * - Wiki links: `[[CSS Cascade Algorithm|CSS cascade]]` should become an
  *   internal essay link whose visible text is `CSS cascade`; `[[CSS Cascade
  *   Algorithm]]` should use the page name as both the destination label and
@@ -35,6 +30,7 @@ import { transformObsidianCallouts } from "./callout";
  * ordinary Markdown instead of carrying Obsidian-specific string handling into
  * rendering components.
  */
-export const remarkObsidianCallouts: Plugin<[], Root> = () => (tree) => {
+export const remarkObsidianMarkdown: Plugin<[], Root> = () => (tree) => {
     transformObsidianCallouts(tree);
+    transformObsidianImageEmbeds(tree);
 };

--- a/src/lib/essays/tests/render.test.ts
+++ b/src/lib/essays/tests/render.test.ts
@@ -110,4 +110,25 @@ describe("renderEssayContent", () => {
         expect(html).toContain('<a href="https://example.com">Docs</a>');
         expect(html).toContain('<a href="#solution">Section</a>');
     });
+
+    it("renders Obsidian image embeds as normalized essay asset images", async () => {
+        const html = await renderEssayHtml(
+            [
+                "![[buttons-without-prefix.png]]",
+                "![[computed-style.png|Computed style panel]]",
+                "![[annotated styles.png|400]]",
+            ].join("\n")
+        );
+
+        expect(html).toContain(
+            '<img src="/essay-assets/buttons-without-prefix.png" alt="buttons-without-prefix.png"/>'
+        );
+        expect(html).toContain(
+            '<img src="/essay-assets/computed-style.png" alt="Computed style panel"/>'
+        );
+        expect(html).toContain(
+            '<img src="/essay-assets/annotated%20styles.png" alt="annotated styles.png" width="400"/>'
+        );
+        expect(html).not.toContain("![[");
+    });
 });


### PR DESCRIPTION
## Summary
- Convert Obsidian image embeds like `![[asset.png]]` into normal essay image nodes before markdown rendering.
- Preserve alias alt text and numeric size hints for embedded images.
- Remove the completed image-embed item from the Obsidian markdown TODO comment while leaving wiki/block links as future work.

## Testing
- Confirmed red regression first: `npx jest src/lib/essays/tests/render.test.ts --runInBand` failed with literal `![[...]]` output.
- `npx jest src/lib/essays/tests/render.test.ts --runInBand`
- `npm test -- --runInBand`
- `npm run lint`
- `npm run build`
- Self-initiated code-clean pass: no mechanical issues found.

## Proof
- Local visual proof saved at `.context/proofs/embed-assets-proof.png`.
- Full-page tiled capture saved under `.context/proofs/screenshot_localhost_2026-06-02T15-34-32-*`.