### PR TITLE
Add giscus essay discussions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,30 @@ bun dev
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
+## Essay Discussions
+
+Essay pages render a `Discuss` section backed by
+[Giscus](https://giscus.app/) and GitHub Discussions. The embed configuration
+lives in `src/lib/giscus.ts` because repository IDs and category IDs are public
+widget identifiers, not secrets.
+
+Required GitHub setup:
+
+- Keep `A-F-V/personal-portfolio` public.
+- Enable GitHub Discussions for the repository.
+- Install the [Giscus GitHub App](https://github.com/apps/giscus) for the
+  repository.
+- Keep the configured discussion category available. The current embed uses the
+  default `Announcements` category because Giscus recommends an announcement
+  category so maintainers and the Giscus app can create discussions while
+  visitors can still comment.
+
+The root `giscus.json` restricts which page origins can load this repository's
+discussions and allows localhost for development. See the Giscus
+[advanced usage guide](https://github.com/giscus/giscus/blob/main/ADVANCED-USAGE.md)
+and GitHub's
+[discussion category documentation](https://docs.github.com/en/discussions/managing-discussions-for-your-community/managing-categories-for-discussions).
+
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.

--- a/giscus.json
+++ b/giscus.json
@@ -1,0 +1,5 @@
+{
+    "origins": ["https://alessandrofv.com", "https://www.alessandrofv.com"],
+    "originsRegex": ["http://localhost:[0-9]+", "http://127\\.0\\.0\\.1:[0-9]+"],
+    "defaultCommentOrder": "newest"
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -61,7 +61,11 @@ const customJestConfig = {
             "ts-jest",
             {
                 useESM: false,
-                tsconfig: "tsconfig.json",
+                // Component tests import TSX directly; keep Next's app tsconfig
+                // JSX-preserve setting out of Jest's CommonJS transform.
+                tsconfig: {
+                    jsx: "react-jsx",
+                },
                 diagnostics: false,
             },
         ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
             "dependencies": {
                 "@babel/preset-env": "^7.28.3",
                 "@babel/preset-typescript": "^7.27.1",
+                "@giscus/react": "^3.1.0",
                 "@next/third-parties": "^15.1.0",
                 "@radix-ui/react-slot": "^1.1.0",
                 "@types/node": "^22.9.1",
@@ -2718,6 +2719,18 @@
             "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
             "license": "MIT"
         },
+        "node_modules/@giscus/react": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@giscus/react/-/react-3.1.0.tgz",
+            "integrity": "sha512-0TCO2TvL43+oOdyVVGHDItwxD1UMKP2ZYpT6gXmhFOqfAJtZxTzJ9hkn34iAF/b6YzyJ4Um89QIt9z/ajmAEeg==",
+            "dependencies": {
+                "giscus": "^1.6.0"
+            },
+            "peerDependencies": {
+                "react": "^16 || ^17 || ^18 || ^19",
+                "react-dom": "^16 || ^17 || ^18 || ^19"
+            }
+        },
         "node_modules/@humanwhocodes/config-array": {
             "version": "0.13.0",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -3882,6 +3895,21 @@
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
+            }
+        },
+        "node_modules/@lit-labs/ssr-dom-shim": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.6.0.tgz",
+            "integrity": "sha512-VHb0ALPMTlgKjM6yIxxoQNnpKyUKLD04VzeQdsiXkMqkvYlAHxq9glGLmgbb889/1GsohSOAjvQYoiBppXFqrQ==",
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@lit/reactive-element": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+            "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@lit-labs/ssr-dom-shim": "^1.5.0"
             }
         },
         "node_modules/@napi-rs/wasm-runtime": {
@@ -7377,6 +7405,12 @@
             "dev": true,
             "license": "MIT",
             "peer": true
+        },
+        "node_modules/@types/trusted-types": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+            "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+            "license": "MIT"
         },
         "node_modules/@types/unist": {
             "version": "3.0.3",
@@ -12281,6 +12315,15 @@
                 "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
             }
         },
+        "node_modules/giscus": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/giscus/-/giscus-1.6.0.tgz",
+            "integrity": "sha512-Zrsi8r4t1LVW950keaWcsURuZUQwUaMKjvJgTCY125vkW6OiEBkatE7ScJDbpqKHdZwb///7FVC21SE3iFK3PQ==",
+            "license": "MIT",
+            "dependencies": {
+                "lit": "^3.2.1"
+            }
+        },
         "node_modules/github-slugger": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
@@ -14820,6 +14863,37 @@
             "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
             "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
             "license": "MIT"
+        },
+        "node_modules/lit": {
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.3.tgz",
+            "integrity": "sha512-fycuvZg/hkpozL00lm1pEJH5nN/lr9ZXd6mJI2HSN4+Bzc+LDNdEApJ6HFbPkdFNHLvOplIIuJvxkS4XUxqirw==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@lit/reactive-element": "^2.1.0",
+                "lit-element": "^4.2.0",
+                "lit-html": "^3.3.0"
+            }
+        },
+        "node_modules/lit-element": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+            "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@lit-labs/ssr-dom-shim": "^1.5.0",
+                "@lit/reactive-element": "^2.1.0",
+                "lit-html": "^3.3.0"
+            }
+        },
+        "node_modules/lit-html": {
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.3.tgz",
+            "integrity": "sha512-el8M6jK2o3RXBnrSHX3ZKrsN8zEV63pSExTO1wYJz7QndGYZ8353e2a5PPX+qHe2aGayfnchQmkAojaWAREOIA==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@types/trusted-types": "^2.0.2"
+            }
         },
         "node_modules/loader-runner": {
             "version": "4.3.2",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "dependencies": {
         "@babel/preset-env": "^7.28.3",
         "@babel/preset-typescript": "^7.27.1",
+        "@giscus/react": "^3.1.0",
         "@next/third-parties": "^15.1.0",
         "@radix-ui/react-slot": "^1.1.0",
         "@types/node": "^22.9.1",

--- a/src/app/(essays)/essay/[slug]/page.tsx
+++ b/src/app/(essays)/essay/[slug]/page.tsx
@@ -6,6 +6,7 @@ import { getEssayBySlug, listEssaySlugs } from "@/lib/essays";
 import { EssayNotFoundError, type EssayDocument } from "@/lib/essays/types";
 import { Essay } from "@/components/essay";
 import { normalizeUrl } from "@/lib/essays/render/remark/asset-url";
+import { createSiteUrl } from "@/lib/site";
 
 interface EssayPageProps {
     params: Promise<{ slug: string }>;
@@ -49,6 +50,9 @@ export async function generateMetadata({
             authors: authors.map((name) => ({ name })),
             alternates: {
                 canonical: canonicalUrl,
+            },
+            other: {
+                "giscus:backlink": createSiteUrl(`/essay/${slug}`),
             },
             openGraph: {
                 title,

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -264,3 +264,13 @@
     color: var(--ctp-peach);
     font-weight: 700;
 }
+
+.essay-discuss .giscus,
+.essay-discuss .giscus-frame {
+    width: 100%;
+}
+
+.essay-discuss .giscus-frame {
+    border: 0;
+    color-scheme: light;
+}

--- a/src/components/essay/discuss.tsx
+++ b/src/components/essay/discuss.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import Giscus from "@giscus/react";
+
+import { giscusEssayConfig } from "@/lib/giscus";
+import { cn } from "@/lib/utils/shadcn";
+
+interface EssayDiscussProps {
+    className?: string;
+}
+
+export function EssayDiscuss({ className }: EssayDiscussProps) {
+    return (
+        <section
+            aria-labelledby="essay-discuss-heading"
+            className={cn(
+                "essay-discuss mt-10 border-t border-foreground/10 pt-8",
+                className
+            )}
+        >
+            <h2
+                id="essay-discuss-heading"
+                className="font-serif text-3xl font-bold leading-tight text-foreground"
+            >
+                Discuss
+            </h2>
+            <div className="mt-5">
+                <Giscus id="essay-discussion" {...giscusEssayConfig} />
+            </div>
+        </section>
+    );
+}

--- a/src/components/essay/discuss.tsx
+++ b/src/components/essay/discuss.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import Giscus from "@giscus/react";
+import {
+    type ComponentType,
+    useEffect,
+    useRef,
+    useState,
+} from "react";
+import type { GiscusProps } from "@giscus/react";
+import { MessageCircle } from "lucide-react";
 
 import { giscusEssayConfig } from "@/lib/giscus";
 import { cn } from "@/lib/utils/shadcn";
@@ -9,23 +16,89 @@ interface EssayDiscussProps {
     className?: string;
 }
 
+type GiscusComponent = ComponentType<GiscusProps>;
+
+const GISCUS_LOAD_ROOT_MARGIN = "300px 0px";
+
+async function loadGiscusComponent(): Promise<GiscusComponent> {
+    const giscusModule = await import("@giscus/react");
+    return giscusModule.default;
+}
+
 export function EssayDiscuss({ className }: EssayDiscussProps) {
+    const sectionRef = useRef<HTMLElement>(null);
+    const [Giscus, setGiscus] = useState<GiscusComponent | null>(null);
+
+    useEffect(() => {
+        let cancelled = false;
+
+        const load = () => {
+            void loadGiscusComponent().then((Component) => {
+                if (!cancelled) {
+                    setGiscus(() => Component);
+                }
+            });
+        };
+
+        const section = sectionRef.current;
+
+        if (!section || typeof IntersectionObserver === "undefined") {
+            load();
+            return () => {
+                cancelled = true;
+            };
+        }
+
+        const observer = new IntersectionObserver(
+            (entries) => {
+                if (!entries.some((entry) => entry.isIntersecting)) {
+                    return;
+                }
+
+                observer.disconnect();
+                load();
+            },
+            { rootMargin: GISCUS_LOAD_ROOT_MARGIN }
+        );
+
+        observer.observe(section);
+
+        return () => {
+            cancelled = true;
+            observer.disconnect();
+        };
+    }, []);
+
     return (
         <section
+            ref={sectionRef}
             aria-labelledby="essay-discuss-heading"
             className={cn(
                 "essay-discuss mt-10 border-t border-foreground/10 pt-8",
                 className
             )}
         >
-            <h2
-                id="essay-discuss-heading"
-                className="font-serif text-3xl font-bold leading-tight text-foreground"
-            >
-                Discuss
-            </h2>
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <h2
+                    id="essay-discuss-heading"
+                    className="inline-flex items-center gap-2 font-serif text-3xl font-bold leading-tight text-foreground"
+                >
+                    <MessageCircle
+                        className="size-5 text-primary"
+                        aria-hidden
+                    />
+                    Discuss
+                </h2>
+                <span className="w-fit rounded-full bg-primary/5 px-2 py-0.5 font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-primary/75">
+                    Powered by Giscus
+                </span>
+            </div>
             <div className="mt-5">
-                <Giscus id="essay-discussion" {...giscusEssayConfig} />
+                {Giscus ? (
+                    <Giscus id="essay-discussion" {...giscusEssayConfig} />
+                ) : (
+                    <div className="min-h-24" aria-hidden />
+                )}
             </div>
         </section>
     );

--- a/src/components/essay/index.tsx
+++ b/src/components/essay/index.tsx
@@ -1,7 +1,8 @@
 import { EssayHeader } from "./header";
-import { EssayDocument } from "@/lib/essays/types";
+import type { EssayDocument } from "@/lib/essays/types";
 import { EssayBody } from "./body";
 import { EssayFooter } from "./footer";
+import { EssayDiscuss } from "./discuss";
 
 interface EssayProps {
     essay: EssayDocument;
@@ -15,6 +16,7 @@ export function Essay({ essay }: EssayProps) {
             <EssayHeader frontMatter={frontMatter} />
             <EssayBody essay={essay} />
             <EssayFooter />
+            <EssayDiscuss />
         </article>
     );
 }

--- a/src/components/essay/tests/discuss.test.tsx
+++ b/src/components/essay/tests/discuss.test.tsx
@@ -23,19 +23,21 @@ describe("EssayDiscuss", () => {
         mockGiscusProps.length = 0;
     });
 
-    it("renders the compact Discuss section with the stable essay discussion mapping", () => {
+    it("renders the compact Discuss section without eagerly loading Giscus", () => {
         const html = renderToStaticMarkup(createElement(EssayDiscuss));
 
         expect(html).toContain('id="essay-discuss-heading"');
         expect(html).toContain(">Discuss<");
-        expect(html).not.toContain("Comments are powered by GitHub Discussions.");
-        expect(mockGiscusProps).toHaveLength(1);
-        expect(mockGiscusProps[0]).toMatchObject({
-            id: "essay-discussion",
-            repo: giscusEssayConfig.repo,
-            repoId: giscusEssayConfig.repoId,
-            category: giscusEssayConfig.category,
-            categoryId: giscusEssayConfig.categoryId,
+        expect(html).toContain("Powered by Giscus");
+        expect(mockGiscusProps).toHaveLength(0);
+    });
+
+    it("keeps the stable essay discussion mapping", () => {
+        expect(giscusEssayConfig).toMatchObject({
+            repo: "A-F-V/personal-portfolio",
+            repoId: "R_kgDOK1iarQ",
+            category: "Announcements",
+            categoryId: "DIC_kwDOK1iarc4C-XDr",
             mapping: "pathname",
             strict: "1",
             reactionsEnabled: "1",

--- a/src/components/essay/tests/discuss.test.tsx
+++ b/src/components/essay/tests/discuss.test.tsx
@@ -1,0 +1,49 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { EssayDiscuss } from "@/components/essay/discuss";
+import { giscusEssayConfig } from "@/lib/giscus";
+
+const mockGiscusProps: Array<Record<string, unknown>> = [];
+
+jest.mock(
+    "@giscus/react",
+    () => ({
+        __esModule: true,
+        default: (props: Record<string, unknown>) => {
+            mockGiscusProps.push(props);
+            return createElement("div", { "data-giscus": "mock" });
+        },
+    }),
+    { virtual: true }
+);
+
+describe("EssayDiscuss", () => {
+    beforeEach(() => {
+        mockGiscusProps.length = 0;
+    });
+
+    it("renders the compact Discuss section with the stable essay discussion mapping", () => {
+        const html = renderToStaticMarkup(createElement(EssayDiscuss));
+
+        expect(html).toContain('id="essay-discuss-heading"');
+        expect(html).toContain(">Discuss<");
+        expect(html).not.toContain("Comments are powered by GitHub Discussions.");
+        expect(mockGiscusProps).toHaveLength(1);
+        expect(mockGiscusProps[0]).toMatchObject({
+            id: "essay-discussion",
+            repo: giscusEssayConfig.repo,
+            repoId: giscusEssayConfig.repoId,
+            category: giscusEssayConfig.category,
+            categoryId: giscusEssayConfig.categoryId,
+            mapping: "pathname",
+            strict: "1",
+            reactionsEnabled: "1",
+            emitMetadata: "0",
+            inputPosition: "bottom",
+            theme: "light",
+            lang: "en",
+            loading: "lazy",
+        });
+    });
+});

--- a/src/components/essay/tests/index.test.tsx
+++ b/src/components/essay/tests/index.test.tsx
@@ -1,0 +1,50 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { Essay } from "@/components/essay";
+import type { EssayDocument } from "@/lib/essays/types";
+
+jest.mock("@/components/essay/header", () => ({
+    EssayHeader: () => createElement("div", { "data-essay-part": "header" }),
+}));
+
+jest.mock("@/components/essay/body", () => ({
+    EssayBody: () => createElement("div", { "data-essay-part": "body" }),
+}));
+
+jest.mock("@/components/essay/footer", () => ({
+    EssayFooter: () => createElement("div", { "data-essay-part": "footer" }),
+}));
+
+jest.mock("@/components/essay/discuss", () => ({
+    EssayDiscuss: () =>
+        createElement("div", { "data-essay-part": "discuss" }),
+}));
+
+const essay: EssayDocument = {
+    slug: "test-essay",
+    filePath: "test-essay.md",
+    content: "Essay content.",
+    frontMatter: {
+        title: "Test Essay",
+        description: "An essay used to verify shell ordering.",
+        slug: "test-essay",
+        publishDate: new Date("2026-06-02"),
+        readingTime: 1,
+        tags: ["test"],
+        authors: ["Test Author"],
+        draft: false,
+    },
+};
+
+describe("Essay", () => {
+    it("renders Discuss after the essay footer", () => {
+        const html = renderToStaticMarkup(createElement(Essay, { essay }));
+
+        expect(html.indexOf('data-essay-part="footer"')).toBeGreaterThan(-1);
+        expect(html.indexOf('data-essay-part="discuss"')).toBeGreaterThan(-1);
+        expect(html.indexOf('data-essay-part="footer"')).toBeLessThan(
+            html.indexOf('data-essay-part="discuss"')
+        );
+    });
+});

--- a/src/lib/giscus.ts
+++ b/src/lib/giscus.ts
@@ -1,0 +1,14 @@
+export const giscusEssayConfig = {
+    repo: "A-F-V/personal-portfolio",
+    repoId: "R_kgDOK1iarQ",
+    category: "Announcements",
+    categoryId: "DIC_kwDOK1iarc4C-XDr",
+    mapping: "pathname",
+    strict: "1",
+    reactionsEnabled: "1",
+    emitMetadata: "0",
+    inputPosition: "bottom",
+    theme: "light",
+    lang: "en",
+    loading: "lazy",
+} as const;


### PR DESCRIPTION
## Summary
Adds giscus-powered discussion embeds to essay pages using pathname mapping and the Announcements discussion category.

## Changes
- Adds @giscus/react, shared giscus config, allowed origins, backlink metadata, and full-width iframe styling.
- Renders a compact Discuss section after the essay footer and covers ordering/config with Jest tests.
- Documents the public repo and GitHub Discussions setup required for giscus.

## Testing
- npm test
- npm run lint
- npm run build
- git diff --check