### PR TITLE
Fix Giscus production origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ Required GitHub setup:
   visitors can still comment.
 
 The root `giscus.json` restricts which page origins can load this repository's
-discussions and allows localhost for development. See the Giscus
+discussions, including the current `alessandrofarace.com` production domain and
+the legacy `alessandrofv.com` redirect domain, and allows localhost for
+development. See the Giscus
 [advanced usage guide](https://github.com/giscus/giscus/blob/main/ADVANCED-USAGE.md)
 and GitHub's
 [discussion category documentation](https://docs.github.com/en/discussions/managing-discussions-for-your-community/managing-categories-for-discussions).

--- a/giscus.json
+++ b/giscus.json
@@ -1,5 +1,10 @@
 {
-    "origins": ["https://alessandrofv.com", "https://www.alessandrofv.com"],
+    "origins": [
+        "https://alessandrofarace.com",
+        "https://www.alessandrofarace.com",
+        "https://alessandrofv.com",
+        "https://www.alessandrofv.com"
+    ],
     "originsRegex": ["http://localhost:[0-9]+", "http://127\\.0\\.0\\.1:[0-9]+"],
     "defaultCommentOrder": "newest"
 }

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -1,6 +1,6 @@
 export const SITE_NAME = "Alessandro Farace";
 export const SITE_DESCRIPTION = "Personal website of Alessandro Farace";
-export const DEFAULT_SITE_URL = "https://alessandrofv.com";
+export const DEFAULT_SITE_URL = "https://alessandrofarace.com";
 export const RSS_FEED_PATH = "/rss.xml";
 
 export function getSiteUrl(): string {


### PR DESCRIPTION
## Summary
Adds alessandrofarace.com and www.alessandrofarace.com to the Giscus origin allowlist while keeping legacy alessandrofv.com origins for redirects.
Updates the default site URL so Giscus backlinks and generated site links use the current production domain.
Documents the current and legacy Giscus domains in the README.

## Testing
- npm test -- --runInBand
- npm run lint
- npm run build
- git diff --check